### PR TITLE
Add model category

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,2 @@
+class Category < ApplicationRecord
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,3 +1,4 @@
 class Service < ApplicationRecord
   belongs_to :user
+  belongs_to :category
 end

--- a/db/migrate/20220811185218_create_categories.rb
+++ b/db/migrate/20220811185218_create_categories.rb
@@ -1,0 +1,10 @@
+class CreateCategories < ActiveRecord::Migration[6.1]
+  def change
+    create_table :categories do |t|
+      t.string :name
+      t.string :image
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220811185219_create_services.rb
+++ b/db/migrate/20220811185219_create_services.rb
@@ -2,6 +2,7 @@ class CreateServices < ActiveRecord::Migration[6.1]
   def change
     create_table :services do |t|
       t.references :user, null: false, foreign_key: true
+      t.references :category, null: false, foreign_key: true
       t.string :name
       t.text :description
       t.string :location

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,6 +27,13 @@ ActiveRecord::Schema.define(version: 2022_08_13_105609) do
     t.index ["user_id"], name: "index_bookings_on_user_id"
   end
 
+  create_table "categories", force: :cascade do |t|
+    t.string "name"
+    t.string "image"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "chatrooms", force: :cascade do |t|
     t.string "name"
     t.bigint "service_id", null: false
@@ -61,6 +68,7 @@ ActiveRecord::Schema.define(version: 2022_08_13_105609) do
 
   create_table "services", force: :cascade do |t|
     t.bigint "user_id", null: false
+    t.bigint "category_id", null: false
     t.string "name"
     t.text "description"
     t.string "location"
@@ -73,6 +81,7 @@ ActiveRecord::Schema.define(version: 2022_08_13_105609) do
     t.boolean "sunday"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["category_id"], name: "index_services_on_category_id"
     t.index ["user_id"], name: "index_services_on_user_id"
   end
 
@@ -103,5 +112,6 @@ ActiveRecord::Schema.define(version: 2022_08_13_105609) do
   add_foreign_key "messages", "users"
   add_foreign_key "reviews", "services"
   add_foreign_key "reviews", "users"
+  add_foreign_key "services", "categories"
   add_foreign_key "services", "users"
 end

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
- [x]  Create the model category (new migration file)
- [x]  Drop the DB
- [x]  Change the timestamp of the category migration file to BEFORE the services migration file (the categories have to be there in order to create a service)
- [x]  change the services migration file by adding t.references :category

Please rails db:drop db:create db:migrate